### PR TITLE
Fix runtime issues on Koha 23.11+

### DIFF
--- a/Koha/Plugin/OAKoha/OAKoha.pl
+++ b/Koha/Plugin/OAKoha/OAKoha.pl
@@ -22,9 +22,9 @@ use warnings;
 
 use CGI qw ( -utf8 );
 
-use C4::Auth;
+use C4::Auth qw(get_template_and_user);
 use C4::Koha;
-use C4::Output;
+use C4::Output qw(output_html_with_http_headers);
 use JSON;
 use Encode qw( encode is_utf8);
 use MIME::Base64;


### PR DESCRIPTION
Hi, this small fix will make the plugin work on 23.11. Right now it is giving compliation errors when `OAKoha.pl` is called.